### PR TITLE
Small fixes to the PING function

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -250,9 +250,10 @@ class ROSDriver(NetworkDriver):
         if source:
             params['src-address'] = source
         if vrf:
-            params['routing-instance'] = vrf
+            params['routing-table'] = vrf
 
         results = self.api('/ping', **params)
+#        return results
 
         ping_results = {
             'probes_sent': max(row['sent'] for row in results),
@@ -260,7 +261,7 @@ class ROSDriver(NetworkDriver):
             'rtt_min': min(float(row.get('min-rtt', '-1ms').replace('ms', '')) for row in results),
             'rtt_max': max(float(row.get('max-rtt', '-1ms').replace('ms', '')) for row in results),
             # Last result has calculated avg
-            'rtt_avg': float(results[-1:][0]['avg-rtt'].replace('ms', '')),
+            'rtt_avg': float(results[-1].get('avg-rtt', '-1ms').replace('ms', '')),
             'rtt_stddev': float(-1),
             'results': []
         }

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -250,7 +250,7 @@ class ROSDriver(NetworkDriver):
         if source:
             params['src-address'] = source
         if vrf:
-            params['routing-instance'] = vrf
+            params['routing-table'] = vrf
 
         results = self.api('/ping', **params)
 

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -260,7 +260,7 @@ class ROSDriver(NetworkDriver):
             'rtt_min': min(float(row.get('min-rtt', '-1ms').replace('ms', '')) for row in results),
             'rtt_max': max(float(row.get('max-rtt', '-1ms').replace('ms', '')) for row in results),
             # Last result has calculated avg
-            'rtt_avg': float(results[-1:][0]['avg-rtt'].replace('ms', '')),
+            'rtt_avg': float(results[-1].get('avg-rtt', '-1ms').replace('ms', '')),,
             'rtt_stddev': float(-1),
             'results': []
         }

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -250,10 +250,9 @@ class ROSDriver(NetworkDriver):
         if source:
             params['src-address'] = source
         if vrf:
-            params['routing-table'] = vrf
+            params['routing-instance'] = vrf
 
         results = self.api('/ping', **params)
-#        return results
 
         ping_results = {
             'probes_sent': max(row['sent'] for row in results),
@@ -261,7 +260,7 @@ class ROSDriver(NetworkDriver):
             'rtt_min': min(float(row.get('min-rtt', '-1ms').replace('ms', '')) for row in results),
             'rtt_max': max(float(row.get('max-rtt', '-1ms').replace('ms', '')) for row in results),
             # Last result has calculated avg
-            'rtt_avg': float(results[-1].get('avg-rtt', '-1ms').replace('ms', '')),
+            'rtt_avg': float(results[-1:][0]['avg-rtt'].replace('ms', '')),
             'rtt_stddev': float(-1),
             'results': []
         }


### PR DESCRIPTION
Line 253, changed 'routing-instance' (due to it failing) to 'routing-table' (tested on 6.38.1, 6.38.7, 6.39.3 and 6.41).

Line 264, fixed an issue where if the target couldn't be pinged resulted in a program's failure due to it not finding the 'avg-rtt' key.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
