### PR TITLE
driver: add get_lldp_neighbors

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -200,6 +200,17 @@ class ROSDriver(NetworkDriver):
 
         return interfaces_ip
 
+    def get_lldp_neighbors(self):
+        neighbours = {}
+        for row in self.api('/ip/neighbor/print'):
+            interface = row['interface']
+            neighbours.setdefault(interface, [])
+            neighbours[interface].append({
+                'hostname': row['identity'],
+                'port': row['interface-name']
+            })
+        return neighbours
+
     def get_ntp_servers(self):
         ntp_servers = {}
         ntp_client_values = self.api('/system/ntp/client/print')[0]


### PR DESCRIPTION
This implements the get_lldp_neighbors feature, this was tested
against a RouterOS system.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
