### PR TITLE
generate consistent interface names for lldp

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -111,12 +111,10 @@ class ROSDriver(NetworkDriver):
             interface_name = '/'.join(entry['interface'].split(',')[::-1])
 
             table.setdefault(interface_name, list())
-            table[interface_name].append(
-                dict(
-                    hostname=entry['identity'],
-                    port=entry['interface-name'],
-                )
-            )
+            table[interface_name].append(dict(
+                hostname=entry['identity'],
+                port=entry['interface-name'],
+            ))
         return table
 
     def get_lldp_neighbors_detail(self, interface=""):
@@ -124,21 +122,20 @@ class ROSDriver(NetworkDriver):
         for entry in self.api('/ip/neighbor/print'):
             # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
             interface_name = '/'.join(entry['interface'].split(',')[::-1])
-            parent_interface = interface_name.split('/')[-1]  # we define the last part of the interface name as parent interface
+            # we define the last part of the interface name as parent interface
+            parent_interface = interface_name.split('/')[-1]
 
             table.setdefault(interface_name, list())
-            table[interface_name].append(
-                dict(
-                    parent_interface=parent_interface,
-                    remote_chassis_id=entry.get('mac-address', ''),
-                    remote_system_name=entry.get('identity', ''),
-                    remote_port=entry.get('interface-name', ''),
-                    remote_port_description='',
-                    remote_system_description=entry.get('system-description', ''),
-                    remote_system_capab=entry.get('system-caps', '').split(','),
-                    remote_system_enable_capab=entry.get('system-caps-enabled', '').split(','),
-                )
-            )
+            table[interface_name].append(dict(
+                parent_interface=parent_interface,
+                remote_chassis_id=entry.get('mac-address', ''),
+                remote_system_name=entry.get('identity', ''),
+                remote_port=entry.get('interface-name', ''),
+                remote_port_description='',
+                remote_system_description=entry.get('system-description', ''),
+                remote_system_capab=entry.get('system-caps', '').split(','),
+                remote_system_enable_capab=entry.get('system-caps-enabled', '').split(','),
+            ))
         if not interface:
             return table
         return table[interface]

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -107,31 +107,36 @@ class ROSDriver(NetworkDriver):
     def get_lldp_neighbors(self):
         table = dict()
         for entry in self.api('/ip/neighbor/print'):
-            for iface in entry['interface'].split(','):
-                table[iface] = list()
-                table[iface].append(dict(
+            interface_name = '/'.join(entry['interface'].split(',')[::-1])  # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
+
+            table.setdefault(interface_name, list())
+            table[interface_name].append(
+                dict(
                     hostname=entry['identity'],
                     port=entry['interface-name'],
-                ))
+                )
+            )
         return table
 
     def get_lldp_neighbors_detail(self, interface=""):
         table = dict()
         for entry in self.api('/ip/neighbor/print'):
-            for iface in entry['interface'].split(','):
-                table[iface] = list()
-                table[iface].append(
-                    dict(
-                        parent_interface=iface,
-                        remote_chassis_id=entry.get('mac-address', ''),
-                        remote_system_name=entry.get('identity', ''),
-                        remote_port=entry.get('interface-name', ''),
-                        remote_port_description='',
-                        remote_system_description=entry.get('system-description', ''),
-                        remote_system_capab=entry.get('system-caps', '').split(','),
-                        remote_system_enable_capab=entry.get('system-caps-enabled', '').split(','),
-                    )
+            interface_name = '/'.join(entry['interface'].split(',')[::-1])  # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
+            parent_interface = interface_name.split('/')[-1]  # we define the last part of the interface name as parent interface
+
+            table.setdefault(interface_name, list())
+            table[interface_name].append(
+                dict(
+                    parent_interface=parent_interface,
+                    remote_chassis_id=entry.get('mac-address', ''),
+                    remote_system_name=entry.get('identity', ''),
+                    remote_port=entry.get('interface-name', ''),
+                    remote_port_description='',
+                    remote_system_description=entry.get('system-description', ''),
+                    remote_system_capab=entry.get('system-caps', '').split(','),
+                    remote_system_enable_capab=entry.get('system-caps-enabled', '').split(','),
                 )
+            )
         if not interface:
             return table
         return table[interface]

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -126,16 +126,18 @@ class ROSDriver(NetworkDriver):
             parent_interface = interface_name.split('/')[-1]
 
             table.setdefault(interface_name, list())
-            table[interface_name].append(dict(
-                parent_interface=parent_interface,
-                remote_chassis_id=entry.get('mac-address', ''),
-                remote_system_name=entry.get('identity', ''),
-                remote_port=entry.get('interface-name', ''),
-                remote_port_description='',
-                remote_system_description=entry.get('system-description', ''),
-                remote_system_capab=entry.get('system-caps', '').split(','),
-                remote_system_enable_capab=entry.get('system-caps-enabled', '').split(','),
-            ))
+            table[interface_name].append(
+                dict(
+                    parent_interface=parent_interface,
+                    remote_chassis_id=entry.get('mac-address', ''),
+                    remote_system_name=entry.get('identity', ''),
+                    remote_port=entry.get('interface-name', ''),
+                    remote_port_description='',
+                    remote_system_description=entry.get('system-description', ''),
+                    remote_system_capab=entry.get('system-caps', '').split(','),
+                    remote_system_enable_capab=entry.get('system-caps-enabled', '').split(','),
+                )
+            )
         if not interface:
             return table
         return table[interface]

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -107,7 +107,8 @@ class ROSDriver(NetworkDriver):
     def get_lldp_neighbors(self):
         table = dict()
         for entry in self.api('/ip/neighbor/print'):
-            interface_name = '/'.join(entry['interface'].split(',')[::-1])  # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
+            # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
+            interface_name = '/'.join(entry['interface'].split(',')[::-1])
 
             table.setdefault(interface_name, list())
             table[interface_name].append(
@@ -121,7 +122,8 @@ class ROSDriver(NetworkDriver):
     def get_lldp_neighbors_detail(self, interface=""):
         table = dict()
         for entry in self.api('/ip/neighbor/print'):
-            interface_name = '/'.join(entry['interface'].split(',')[::-1])  # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
+            # interface names are the reversed interface e.g. sfp-sfpplus1,bridge will become bridge/sfp-sfpplus1
+            interface_name = '/'.join(entry['interface'].split(',')[::-1])
             parent_interface = interface_name.split('/')[-1]  # we define the last part of the interface name as parent interface
 
             table.setdefault(interface_name, list())

--- a/tests/unit/mocked_data/test_get_lldp_neighbors/multi_interface/expected_result.json
+++ b/tests/unit/mocked_data/test_get_lldp_neighbors/multi_interface/expected_result.json
@@ -1,11 +1,5 @@
 {
-    "ether3": [
-        {
-            "hostname":"sw",
-            "port": "ether1"
-        }
-    ],
-    "br-lan": [
+    "br-lan/ether3": [
         {
             "hostname":"sw",
             "port": "ether1"

--- a/tests/unit/mocked_data/test_get_lldp_neighbors_detail/multi_interface/expected_result.json
+++ b/tests/unit/mocked_data/test_get_lldp_neighbors_detail/multi_interface/expected_result.json
@@ -1,22 +1,7 @@
 {
-    "ether3": [
+    "br-lan/ether3": [
         {
             "parent_interface": "ether3",
-            "remote_chassis_id": "4C:5E:0C:12:AA:CC",
-            "remote_system_name":"sw",
-            "remote_port": "ether1",
-            "remote_system_description": "MikroTik RouterOS 6.40.8 (bugfix) CRS112-8G-4S",
-            "remote_port_description": "",
-            "remote_system_capab": [
-                "bridge",
-                "router"
-            ],
-            "remote_system_enable_capab": ["router"]
-        }
-    ],
-    "br-lan": [
-        {
-            "parent_interface": "br-lan",
             "remote_chassis_id": "4C:5E:0C:12:AA:CC",
             "remote_system_name":"sw",
             "remote_port": "ether1",


### PR DESCRIPTION
Since the switches announce over lldp that the interface is named bridge/interface, i changed the lldp methodes to use consistent interface names here. So they can be matched for example in netbox correctyl.