### PR TITLE
Fix get mac address table

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -100,7 +100,7 @@ class ROSDriver(NetworkDriver):
                     last_move=0.0,
                 )
             )
-            
+
         return table
 
     def get_network_instances(self, name=""):

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -87,7 +87,7 @@ class ROSDriver(NetworkDriver):
 
     def get_mac_address_table(self):
         table = list()
-        for entry in self.api('/interface/bridge/host/print'):         
+        for entry in self.api('/interface/bridge/host/print'):
             table.append(
                 dict(
                     mac=entry['mac-address'],
@@ -100,6 +100,7 @@ class ROSDriver(NetworkDriver):
                     last_move=0.0,
                 )
             )
+            
         return table
 
     def get_network_instances(self, name=""):

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -100,6 +100,22 @@ class ROSDriver(NetworkDriver):
                 )
             )
 
+        try:
+            for entry in self.api('/interface/ethernet/switch/unicast-fdb/print'):
+                table.append(
+                    dict(
+                        mac=entry['mac-address'],
+                        interface=entry['port'],
+                        vlan=entry['vlan-id'],
+                        static=not entry['dynamic'],
+                        active=entry['active'],
+                        moves=0,
+                        last_move=0.0,
+                    )
+                )
+        except librouteros.exceptions.TrapError:
+            pass # This only exists in the CRS1XX and CRS2XX switches
+
         return table
 
     def get_network_instances(self, name=""):

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -87,14 +87,15 @@ class ROSDriver(NetworkDriver):
 
     def get_mac_address_table(self):
         table = list()
-        for entry in self.api('/interface/ethernet/switch/unicast-fdb/print'):
+        for entry in self.api('/interface/bridge/host/print'):         
             table.append(
                 dict(
                     mac=entry['mac-address'],
-                    interface=entry['port'],
-                    vlan=entry['vlan-id'],
+                    interface=entry['interface'],
+                    # The vid is not consistently set in the API
+                    vlan=entry.get('vid', 0),
                     static=not entry['dynamic'],
-                    active=entry['active'],
+                    active=not entry['invalid'],
                     moves=0,
                     last_move=0.0,
                 )

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -92,8 +92,7 @@ class ROSDriver(NetworkDriver):
                 dict(
                     mac=entry['mac-address'],
                     interface=entry['interface'],
-                    # The vid is not consistently set in the API
-                    vlan=entry.get('vid', 0),
+                    vlan=entry.get('vid', 0),     # The vid is not consistently set in the API
                     static=not entry['dynamic'],
                     active=not entry['invalid'],
                     moves=0,

--- a/tests/unit/mocked_data/test_get_mac_address_table/static_and_dynamic/_interface_bridge_host_print.json
+++ b/tests/unit/mocked_data/test_get_mac_address_table/static_and_dynamic/_interface_bridge_host_print.json
@@ -1,0 +1,43 @@
+{
+    "data": [
+        {
+            '.id': '*131',
+            'bridge': 'Inside',
+            'disabled': False,
+            'dynamic': True,
+            'external': False,
+            'interface': 'ether4',
+            'invalid': False,
+            'local': True,
+            'mac-address': '11:33:55:77:99:AA',
+            'on-interface': 'ether4'
+        },
+        {
+            ".id": "*143",
+            "age": "7s",
+            "bridge": "Inside",
+            "disabled": False,
+            "dynamic": True,
+            "external": False,
+            "interface": "ether3",
+            "invalid": False,
+            "local": False,
+            "mac-address": "11:22:33:44:55:66",
+            "on-interface": "ether3",
+            "vid": 1
+        },
+        {
+            ".id": "*13B",
+            "bridge": "DMZ",
+            "disabled": False,
+            "dynamic": True,
+            "external": False,
+            "interface": "sfp-sfpplus3",
+            "invalid": False,
+            "local": True,
+            "mac-address": "AA:BB:CC:DD:EE:FF",
+            "on-interface": "sfp-sfpplus3",
+            "vid": 5
+        }
+    ]
+}

--- a/tests/unit/mocked_data/test_get_mac_address_table/static_and_dynamic/_interface_bridge_host_print.json
+++ b/tests/unit/mocked_data/test_get_mac_address_table/static_and_dynamic/_interface_bridge_host_print.json
@@ -1,16 +1,16 @@
 {
     "data": [
         {
-            '.id': '*131',
-            'bridge': 'Inside',
-            'disabled': False,
-            'dynamic': True,
-            'external': False,
-            'interface': 'ether4',
-            'invalid': False,
-            'local': True,
-            'mac-address': '11:33:55:77:99:AA',
-            'on-interface': 'ether4'
+            ".id": "*131",
+            "bridge": "Inside",
+            "disabled": False,
+            "dynamic": True,
+            "external": False,
+            "interface": "ether4",
+            "invalid": False,
+            "local": True,
+            "mac-address": "11:33:55:77:99:AA",
+            "on-interface": "ether4"
         },
         {
             ".id": "*143",

--- a/tests/unit/mocked_data/test_get_mac_address_table/static_and_dynamic/expected_result.json
+++ b/tests/unit/mocked_data/test_get_mac_address_table/static_and_dynamic/expected_result.json
@@ -1,5 +1,32 @@
 [
     {
+        "mac": "11:33:55:77:99:AA",
+        "interface": "ether4",
+        "vlan": 0,
+        "static": false,
+        "active": true,
+        "moves": 0,
+        "last_move": 0
+    },
+    {
+        "mac": "11:22:33:44:55:66",
+        "interface": "ether3",
+        "vlan": 1,
+        "static": false,
+        "active": true,
+        "moves": 0,
+        "last_move": 0
+    },
+    {
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "interface": "sfp-sfpplus3",
+        "vlan": 5,
+        "static": false,
+        "active": true,
+        "moves": 0,
+        "last_move": 0
+    },
+    {
         "mac": "00:00:00:11:11:11",
         "interface": "sfp9",
         "vlan": 0,


### PR DESCRIPTION
The Ethernet switch section has been re-absorbed back into the generic bridge implementation (controlled by the hardware offload tag).

Mikrotik has a concept of untagged similar to Juniper in the case where the vlan ID is not set it is set to 0.