### PR TITLE
#83 - Fix get_interfaces_counters key errors when interface not running

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -58,10 +58,10 @@ class ROSDriver(NetworkDriver):
         for iface in self.api('/interface/print', stats=True):
             result[iface['name']] = defaultdict(int)
             stats = result[iface['name']]
-            stats['tx_errors'] += iface['tx-error']
-            stats['rx_errors'] += iface['rx-error']
-            stats['tx_discards'] += iface['tx-drop']
-            stats['rx_discards'] += iface['rx-drop']
+            stats['tx_errors'] += iface.get('tx-error', 0)
+            stats['rx_errors'] += iface.get('rx-error', 0)
+            stats['tx_discards'] += iface.get('tx-drop', 0)
+            stats['rx_discards'] += iface.get('rx-drop', 0)
             stats['tx_octets'] += iface['tx-byte']
             stats['rx_octets'] += iface['rx-byte']
             stats['tx_unicast_packets'] += iface['tx-packet']

--- a/tests/unit/mocked_data/test_get_interfaces_counters/running_false/_interface_print.json
+++ b/tests/unit/mocked_data/test_get_interfaces_counters/running_false/_interface_print.json
@@ -1,0 +1,28 @@
+{
+    "data":
+    [
+        {
+            ".id": "*1",
+            "actual-mtu": 1500,
+            "default-name": "ether1",
+            "disabled": false,
+            "fp-rx-byte": 0,
+            "fp-rx-packet": 0,
+            "fp-tx-byte": 0,
+            "fp-tx-packet": 0,
+            "l2mtu": 1592,
+            "link-downs": 0,
+            "mac-address": "D4:CA:6D:26:05:F7",
+            "max-l2mtu": 9578,
+            "mtu": 1500,
+            "name": "ether1poe",
+            "running": false,
+            "rx-byte": 0,
+            "rx-packet": 0,
+            "tx-byte": 0,
+            "tx-packet": 0,
+            "tx-queue-drop": 0,
+            "type": "ether"
+        }
+    ]
+}

--- a/tests/unit/mocked_data/test_get_interfaces_counters/running_false/expected_result.json
+++ b/tests/unit/mocked_data/test_get_interfaces_counters/running_false/expected_result.json
@@ -1,0 +1,16 @@
+{
+    "ether1poe": {
+        "rx_unicast_packets": 0,
+        "rx_octets": 0,
+        "rx_errors": 0,
+        "rx_discards": 0,
+        "tx_unicast_packets": 0,
+        "tx_octets": 0,
+        "tx_errors": 0,
+        "tx_discards": 0,
+        "tx_multicast_packets": 0,
+        "rx_multicast_packets": 0,
+        "tx_broadcast_packets": 0,
+        "rx_broadcast_packets": 0
+    }
+}


### PR DESCRIPTION
This should fix #83 

It looks like tx/rx drop and error counters are not present in the Mikrotik api response when an interface is not running (running: False in api response)
