### PR TITLE
Update ros.py to support CHR

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -345,7 +345,7 @@ class ROSDriver(NetworkDriver):
     def get_facts(self):
         resource = tuple(self.api('/system/resource/print'))[0]
         identity = tuple(self.api('/system/identity/print'))[0]
-        if  resource['board-name'] == 'CHR':
+        if resource['board-name'] == 'CHR':
             serial_number = ''
         else:
             routerboard = tuple(self.api('/system/routerboard/print'))[0]

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -345,7 +345,11 @@ class ROSDriver(NetworkDriver):
     def get_facts(self):
         resource = tuple(self.api('/system/resource/print'))[0]
         identity = tuple(self.api('/system/identity/print'))[0]
-        routerboard = tuple(self.api('/system/routerboard/print'))[0]
+        if  resource['board-name'] == 'CHR':
+            serial_number = ''
+        else:
+            routerboard = tuple(self.api('/system/routerboard/print'))[0]
+            serial_number = routerboard.get('serial-number', '')
         interfaces = tuple(self.api('/interface/print'))
         return {
             'uptime': to_seconds(resource['uptime']),
@@ -354,7 +358,7 @@ class ROSDriver(NetworkDriver):
             'hostname': identity['name'],
             'fqdn': '',
             'os_version': resource['version'],
-            'serial_number': routerboard.get('serial-number', ''),
+            'serial_number': serial_number,
             'interface_list': napalm.base.utils.string_parsers.sorted_nicely(
                 tuple(iface['name'] for iface in interfaces),
             ),

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -369,7 +369,7 @@ class ROSDriver(NetworkDriver):
                 'description': entry.get('comment', ''),
                 'last_flapped': -1.0,
                 'mtu': entry.get('actual-mtu', 0),
-                'speed': -1,
+                'speed': -1.0,
                 'mac_address': cast_mac(entry['mac-address']) if entry.get('mac-address') else '',
             }
         return interfaces

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from itertools import chain
 import socket
 import ssl
-import paramiko
 
 # Import third party libs
 from librouteros import connect
@@ -364,21 +363,6 @@ class ROSDriver(NetworkDriver):
                 tuple(iface['name'] for iface in interfaces),
             ),
         }
-
-    
-    def get_config(self,retrieve='all', full=False, sanitized=False):
-        if retrieve=='candidate' or retrieve=='startup':
-            return { retrieve: ''}
-        command="export terse"
-        if full:
-            command=command + " verbose"
-        if not sanitized:
-            command=command + " show-sensitive"
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(self.hostname, port=22, username=self.username, password=self.password)
-        stdin, stdout, stderr = ssh.exec_command(command)
-        return { 'running': stdout.read().decode(), 'candidate': '', 'startup' : '' }
 
     def get_interfaces(self):
         interfaces = {}

--- a/tests/unit/mocked_data/test_get_interfaces/last-link-up-time/expected_result.json
+++ b/tests/unit/mocked_data/test_get_interfaces/last-link-up-time/expected_result.json
@@ -3,7 +3,7 @@
         "is_up": true,
         "is_enabled": true,
         "description": "",
-        "last_flapped": -1,
+        "last_flapped": -1.0,
         "speed": -1,
         "mac_address": "08:00:27:A9:3F:55",
         "mtu": 1500

--- a/tests/unit/mocked_data/test_get_interfaces/normal/expected_result.json
+++ b/tests/unit/mocked_data/test_get_interfaces/normal/expected_result.json
@@ -3,8 +3,8 @@
         "is_up": true,
         "is_enabled": true,
         "description": "",
-        "last_flapped": -1,
-        "speed": -1,
+        "last_flapped": -1.0,
+        "speed": -1.0,
         "mtu": 1500,
         "mac_address": "08:00:27:A9:3F:55"
     }


### PR DESCRIPTION
Previous implementation supposed there was always a routerboard method, however this isn't true for CHR, where a serial number isn't also available.
