### PR TITLE
Update ros.py to add get_config

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from itertools import chain
 import socket
 import ssl
+import paramiko
 
 # Import third party libs
 from librouteros import connect
@@ -359,6 +360,20 @@ class ROSDriver(NetworkDriver):
                 tuple(iface['name'] for iface in interfaces),
             ),
         }
+
+    def get_config(self,retrieve='all', full=False, sanitized=False):
+        if retrieve in ('candidate', 'startup'):
+            return { retrieve: ''}
+        command="export terse"
+        if full:
+            command=command + " verbose"
+        if not sanitized:
+            command=command + " show-sensitive"
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.connect(self.hostname, port=22, username=self.username, password=self.password)
+        stdin, stdout, stderr = ssh.exec_command(command)
+        return { 'running': stdout.read().decode(), 'candidate': '', 'startup' : '' }
 
     def get_interfaces(self):
         interfaces = {}

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -361,18 +361,18 @@ class ROSDriver(NetworkDriver):
             ),
         }
 
-    def get_config(self,retrieve='all', full=False, sanitized=False):
-        command="export terse"
+    def get_config(self, retrieve='all', full=False, sanitized=False):
+        command = "export terse"
         if full:
-            command=command + " verbose"
+            command = command + " verbose"
         if not sanitized:
-            command=command + " show-sensitive"
+            command = command + " show-sensitive"
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(self.hostname, port=22, username=self.username, password=self.password)
         _, stdout, _ = ssh.exec_command(command)
         config = stdout.read().decode()
-        return { 'running': config, 'candidate': config, 'startup' : config }
+        return {'running': config, 'candidate': config, 'startup': config}
 
     def get_interfaces(self):
         interfaces = {}

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -362,8 +362,6 @@ class ROSDriver(NetworkDriver):
         }
 
     def get_config(self,retrieve='all', full=False, sanitized=False):
-        if retrieve in ('candidate', 'startup'):
-            return { retrieve: ''}
         command="export terse"
         if full:
             command=command + " verbose"
@@ -372,8 +370,9 @@ class ROSDriver(NetworkDriver):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(self.hostname, port=22, username=self.username, password=self.password)
-        stdin, stdout, stderr = ssh.exec_command(command)
-        return { 'running': stdout.read().decode(), 'candidate': '', 'startup' : '' }
+        _, stdout, _ = ssh.exec_command(command)
+        config = stdout.read().decode()
+        return { 'running': config, 'candidate': config, 'startup' : config }
 
     def get_interfaces(self):
         interfaces = {}


### PR DESCRIPTION
Added a get_config function supporting the extraction of a running config with full and/or sanitized support.

NAPALM documentation lacks the definition if the return of the function should contain all versions or only the selected one so I followed what I've seen happening with the srl code.
