### PR TITLE
[WIP] feat: add ssh arguments pathrough

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -76,7 +76,7 @@ class ROSDriver(NetworkDriver):
 
         self.ssl_wrapper = self.optional_args.get('ssl_wrapper', librouteros.DEFAULTS['ssl_wrapper'])
         self.port = self.optional_args.get('port', 8729 if 'ssl_wrapper' in self.optional_args else 8728)
-        self.ssh_port = self.optional_args.get('ssh_port', 22)
+        self.paramiko_optional_args = {k[4:]: v for k, v in self.optional_args.items() if k.startswith("ssh_")}
         self.api = None
         self.ssh = None
 
@@ -370,7 +370,13 @@ class ROSDriver(NetworkDriver):
             command.append("show-sensitive")
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
-        self.ssh.connect(self.hostname, port=self.ssh_port, username=self.username, password=self.password)
+        paramiko_connect_args = {
+            "hostname": self.hostname,
+            "username": self.username,
+            "password": self.password,
+            **self.paramiko_optional_args,
+        }
+        self.ssh.connect(**paramiko_connect_args)
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()
         # remove date/time in 1st line


### PR DESCRIPTION
### Description:

This adds an optional argument skimmer to implement SSH arguments passthrough.
For clarity purposes, `ssh_port` attribute is removed from the `ROSDriver` class in favor of a unified `paramiko_optional_args` attribute, which may be classified a **BREAKING CHANGE**.

### Check off the following:

- [x] I have read contributing [guide](CONTRIBUTING.md)
