### PR TITLE
Paramiko fix for looking for keys

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -54,7 +54,7 @@ class ROSDriver(NetworkDriver):
     platform = 'ros'
 
     # pylint: disable=super-init-not-called
-    def __init__(self, hostname, username, password, timeout=60, optional_args=None):
+    def __init__(self, hostname, username, password, timeout=60, optional_args=None, look_for_keys=False):
         self.hostname = hostname
         self.username = username
         self.password = password


### PR DESCRIPTION
Connecting to Router OS to obtain a configuration via SSH would give an error stating wrong credentials. Credentials are fine, on the router the error log shows:

"ssh,error expected msg: 50 got: 5"

The solution is to not look for local keys, maybe this is not the best practice, but since we already add keys automatically I don't think would be a bigger issue.

### Description:

<!-- 
If there's an existing issue for your change, please link to it in above.
Describe what you need to change and why.
-->

### Check off the following:

- [x] I have read contributing [guide](CONTRIBUTING.md)
