### PR TITLE
Connection Fix

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -372,7 +372,11 @@ class ROSDriver(NetworkDriver):
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
         self.ssh.connect(
-            self.hostname, port=self.ssh_port, username=self.username, password=self.password, look_for_keys=self.paramiko_look_for_keys
+            self.hostname, 
+            port=self.ssh_port, 
+            username=self.username, 
+            password=self.password, 
+            look_for_keys=self.paramiko_look_for_keys
         )
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -370,7 +370,8 @@ class ROSDriver(NetworkDriver):
             command.append("show-sensitive")
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
-        self.ssh.connect(self.hostname, port=self.ssh_port, username=self.username, password=self.password, look_for_keys=False)
+        self.ssh.connect(self.hostname, port=self.ssh_port, 
+                         username=self.username, password=self.password, look_for_keys=False)
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()
         # remove date/time in 1st line

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -370,7 +370,7 @@ class ROSDriver(NetworkDriver):
             command.append("show-sensitive")
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
-        self.ssh.connect(self.hostname, port=self.ssh_port, username=self.username, password=self.password, look_for_keys=False))
+        self.ssh.connect(self.hostname, port=self.ssh_port, username=self.username, password=self.password, look_for_keys=False)
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()
         # remove date/time in 1st line

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -376,7 +376,7 @@ class ROSDriver(NetworkDriver):
             port=self.ssh_port,
             username=self.username,
             password=self.password,
-            look_for_keys=self.paramiko_look_for_keys
+            look_for_keys=self.paramiko_look_for_keys,
         )
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -77,6 +77,7 @@ class ROSDriver(NetworkDriver):
         self.ssl_wrapper = self.optional_args.get('ssl_wrapper', librouteros.DEFAULTS['ssl_wrapper'])
         self.port = self.optional_args.get('port', 8729 if 'ssl_wrapper' in self.optional_args else 8728)
         self.ssh_port = self.optional_args.get('ssh_port', 22)
+        self.paramiko_look_for_keys = self.optional_args.get('paramiko_look_for_keys', False)
         self.api = None
         self.ssh = None
 
@@ -370,8 +371,9 @@ class ROSDriver(NetworkDriver):
             command.append("show-sensitive")
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
-        self.ssh.connect(self.hostname, port=self.ssh_port,
-                         username=self.username, password=self.password, look_for_keys=False)
+        self.ssh.connect(
+            self.hostname, port=self.ssh_port, username=self.username, password=self.password, look_for_keys=self.paramiko_look_for_keys
+        )
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()
         # remove date/time in 1st line

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -372,10 +372,10 @@ class ROSDriver(NetworkDriver):
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
         self.ssh.connect(
-            self.hostname, 
-            port=self.ssh_port, 
-            username=self.username, 
-            password=self.password, 
+            self.hostname,
+            port=self.ssh_port,
+            username=self.username,
+            password=self.password,
             look_for_keys=self.paramiko_look_for_keys
         )
         _, stdout, _ = self.ssh.exec_command(" ".join(command))

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -370,7 +370,7 @@ class ROSDriver(NetworkDriver):
             command.append("show-sensitive")
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
-        self.ssh.connect(self.hostname, port=self.ssh_port, 
+        self.ssh.connect(self.hostname, port=self.ssh_port,
                          username=self.username, password=self.password, look_for_keys=False)
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -370,7 +370,7 @@ class ROSDriver(NetworkDriver):
             command.append("show-sensitive")
         if version.major <= 6 and sanitized:
             command.append("hide-sensitive")
-        self.ssh.connect(self.hostname, port=self.ssh_port, username=self.username, password=self.password)
+        self.ssh.connect(self.hostname, port=self.ssh_port, username=self.username, password=self.password, look_for_keys=False))
         _, stdout, _ = self.ssh.exec_command(" ".join(command))
         config = stdout.read().decode().strip()
         # remove date/time in 1st line


### PR DESCRIPTION
### Description:

Connecting to Router OS to obtain a configuration via SSH would give an error stating wrong credentials. Credentials are fine, on the router the error log shows:

"ssh,error expected msg: 50 got: 5"

The solution is to not look for local keys, maybe this is not the best practice, but since we already add keys automatically I don't think would be a bigger issue.

### Check off the following:

- [ x] I have read contributing [guide](CONTRIBUTING.md)
