### PR TITLE
Use poetry-core build backend to fix release versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=56.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "napalm-ros"
-version="1.3.0"
+version="1.3.1"
 description="Network Automation and Programmability Abstraction Layer driver for Mikrotik ROS"
 readme = "README.md"
 authors = ["Łukasz Kostka <lukasz.g.kostka@gmail.com>"]


### PR DESCRIPTION
## Problem

The 1.3.0 release published `napalm_ros-0.0.0` to PyPI instead of `1.3.0`. The `Release` workflow went green, but its publish step built and uploaded 0.0.0:

```
Building napalm-ros (1.3.0)
Publishing napalm-ros (0.0.0) to PyPI
 - Uploading napalm_ros-0.0.0.tar.gz
 - Uploading napalm_ros-0.0.0-py3-none-any.whl
```

PyPI still shows 1.2.6 as latest only because 0.0.0 sorts below it, so 1.3.0 never actually shipped and a junk 0.0.0 is now in the index.

## Cause

`[build-system]` declared `setuptools.build_meta` as the backend, while the version lives under `[tool.poetry]` (there is no `[project]` table, `setup.py`, or `setup.cfg`). Newer poetry on the CI runner delegates the build to the declared backend, so setuptools built the artifacts with its default version of `0.0.0` because it cannot read poetry's version. This previously worked only because older poetry always built via poetry-core regardless of `[build-system]`.

## Fix

Point the backend at `poetry-core` so the build reads the version from `[tool.poetry]`, and bump to `1.3.1` for a clean re-release.

Verified with an isolated PEP 517 build against the declared backend:

```
Successfully built napalm_ros-1.3.1.tar.gz and napalm_ros-1.3.1-py3-none-any.whl
```

## After merge

- Tag `1.3.1` to re-release (this time it publishes the correct version).
- The stray `napalm_ros-0.0.0` should be yanked from PyPI; that needs PyPI project access rather than repo access.
