### PR TITLE
Close the SSH client used by get_config and guard close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ As napalm-ros uses API, several caveats exist.
 
 * API is not versioned so things may break when routeros is upgraded.
 * RouterOS has no native, non-reboot commit/rollback and safe mode is not exposed via the API. Rollback is emulated with a device-side scheduler that restores a backup, so a rollback (or an expired commit-confirm) reverts by rebooting. See Configuration management.
+* `get_config` retrieves the running configuration over SSH (paramiko). By default paramiko offers keys from a running SSH agent; if the agent offers a key the device rejects, RouterOS may drop the session and `get_config` then fails with `No existing session`. Pass `optional_args={'paramiko_allow_agent': False}` to authenticate with the password only (SSH agent/key auth is otherwise left enabled). `paramiko_look_for_keys` (default `False`) similarly controls on-disk key lookup.
 
 
 ### Configuration management

--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -69,6 +69,11 @@ class ROSDriver(NetworkDriver):
         self.port = self.optional_args.get('port', 8729 if 'ssl_wrapper' in self.optional_args else 8728)
         self.ssh_port = self.optional_args.get('ssh_port', 22)
         self.paramiko_look_for_keys = self.optional_args.get('paramiko_look_for_keys', False)
+        # paramiko's allow_agent default (True) is preserved so SSH key/agent auth keeps
+        # working unchanged. If an SSH agent offers keys the device rejects, RouterOS can
+        # drop the session and get_config then fails with "No existing session"; set
+        # paramiko_allow_agent=False in optional_args to work around that.
+        self.paramiko_allow_agent = self.optional_args.get('paramiko_allow_agent', True)
         self.api = None
         self.ssh = None
         # Buffered candidate configuration (set by load_*_candidate, applied by commit_config).
@@ -76,7 +81,10 @@ class ROSDriver(NetworkDriver):
         self._config_replace = False
 
     def close(self):
-        self.api.close()
+        if self.api is not None:
+            self.api.close()
+        if self.ssh is not None:
+            self.ssh.close()
 
     def is_alive(self):
         '''No ping method is exposed from API'''
@@ -369,9 +377,13 @@ class ROSDriver(NetworkDriver):
             username=self.username,
             password=self.password,
             look_for_keys=self.paramiko_look_for_keys,
+            allow_agent=self.paramiko_allow_agent,
         )
-        _, stdout, _ = self.ssh.exec_command(" ".join(command))
-        config = stdout.read().decode().strip()
+        try:
+            _, stdout, _ = self.ssh.exec_command(" ".join(command))
+            config = stdout.read().decode().strip()
+        finally:
+            self.ssh.close()
         # remove date/time in 1st line
         config = re.sub(r"^# \S+ \S+ by (.+)$", r'# by \1', config, flags=re.MULTILINE)
         if retrieve in ("running", "all"):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -101,6 +101,9 @@ class FakeSSH(BaseTestDouble):
     def connect(self, *args, **kwargs):
         pass
 
+    def close(self, *args, **kwargs):
+        pass
+
 
 class FakeApi(BaseTestDouble):
 


### PR DESCRIPTION
- `get_config()` opened a paramiko SSH connection per call but never closed it, leaking a transport each time; `close()` left the last one open. Close SSH after each `get_config()` and in `close()`.
- `close()` called `self.api.close()` even when `open()` had failed (`api is None`), raising `AttributeError` and masking the real error. Guard both `api` and `ssh`.
- Add `paramiko_allow_agent` (default `True`, so auth behaviour is unchanged) as a documented opt-out: with a loaded SSH agent RouterOS can drop the session and `get_config` fails with `No existing session`; set it `False` for password-only.

Validated live on a 7.21.5 CHR; 63 unit tests pass.
