### PR TITLE
Skip the None NTP server when secondary-ntp is unset

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -501,7 +501,7 @@ class ROSDriver(NetworkDriver):
         secondary_ntp = ntp_client_values.get('secondary-ntp')
         if primary_ntp and primary_ntp != '0.0.0.0':
             ntp_servers[primary_ntp] = {}
-        if secondary_ntp != '0.0.0.0':
+        if secondary_ntp and secondary_ntp != '0.0.0.0':
             ntp_servers[secondary_ntp] = {}
         return ntp_servers
 

--- a/tests/unit/mocked_data/test_get_ntp_servers/fqdn_only_without_ntp_ip_fields/_system_ntp_client_print.json
+++ b/tests/unit/mocked_data/test_get_ntp_servers/fqdn_only_without_ntp_ip_fields/_system_ntp_client_print.json
@@ -1,0 +1,10 @@
+{
+    "data": [
+        {
+            "server-dns-names": "0.pool.ntp.org,1.pool.ntp.org",
+            "enabled": true,
+            "mode": "unicast",
+            "active-server": "91.212.242.21"
+        }
+    ]
+}

--- a/tests/unit/mocked_data/test_get_ntp_servers/fqdn_only_without_ntp_ip_fields/expected_result.json
+++ b/tests/unit/mocked_data/test_get_ntp_servers/fqdn_only_without_ntp_ip_fields/expected_result.json
@@ -1,0 +1,4 @@
+{
+    "0.pool.ntp.org": {},
+    "1.pool.ntp.org": {}
+}


### PR DESCRIPTION
`get_ntp_servers` guarded `primary-ntp` with a truthiness check but not `secondary-ntp`. When the NTP client has no `secondary-ntp` field (e.g. a DNS-only client on RouterOS 7), `secondary_ntp` is `None` and `None != '0.0.0.0'` inserted a bogus `None` key into the result. Guard `secondary-ntp` the same way as `primary-ntp`.

Adds a `get_ntp_servers` test scenario for a DNS-only client with no NTP IP fields.
