### PR TITLE
Make is_alive probe the connection instead of hardcoding True

### DIFF
--- a/napalm_ros/ros.py
+++ b/napalm_ros/ros.py
@@ -10,7 +10,7 @@ import napalm.base.constants as C
 import napalm.base.utils.string_parsers
 import paramiko
 from librouteros import connect
-from librouteros.exceptions import FatalError, MultiTrapError, TrapError
+from librouteros.exceptions import ConnectionClosed, FatalError, MultiTrapError, TrapError
 from librouteros.query import (
     And,
     Key,
@@ -79,7 +79,14 @@ class ROSDriver(NetworkDriver):
         self.api.close()
 
     def is_alive(self):
-        '''No ping method is exposed from API'''
+        # The binary API exposes no ping/keepalive, so probe with a cheap read to tell a
+        # dropped or rebooted session apart from a live one.
+        if self.api is None:
+            return {'is_alive': False}
+        try:
+            next(iter(self.api('/system/identity/print')))
+        except (ConnectionClosed, FatalError, OSError):
+            return {'is_alive': False}
         return {'is_alive': True}
 
     def get_interfaces_counters(self):

--- a/tests/unit/mocked_data/test_is_alive/normal/_system_identity_print.json
+++ b/tests/unit/mocked_data/test_is_alive/normal/_system_identity_print.json
@@ -1,0 +1,7 @@
+{
+    "data": [
+        {
+            "name": "MikroTik"
+        }
+    ]
+}

--- a/tests/unit/test_config_management.py
+++ b/tests/unit/test_config_management.py
@@ -13,7 +13,7 @@ from napalm.base.exceptions import (
     MergeConfigException,
     ReplaceConfigException,
 )
-from librouteros.exceptions import TrapError
+from librouteros.exceptions import ConnectionClosed, TrapError
 
 from napalm_ros.ros import ROLLBACK_SNAPSHOT, REVERT_JOB, ROSDriver
 
@@ -212,3 +212,20 @@ def test_rollback_without_snapshot_raises():
     with pytest.raises(CommitError):
         driver.rollback()
     cfg.backup_load.assert_not_called()
+
+
+def test_is_alive_true_when_api_responds():
+    driver, _ = make_driver()
+    driver.api.return_value = iter([{'name': 'MikroTik'}])
+    assert driver.is_alive() == {'is_alive': True}
+
+
+def test_is_alive_false_on_dropped_connection():
+    driver, _ = make_driver()
+    driver.api.side_effect = ConnectionClosed('connection dropped')
+    assert driver.is_alive() == {'is_alive': False}
+
+
+def test_is_alive_false_when_not_opened():
+    driver = ROSDriver('host', 'user', 'pass')  # open() never called, so api is None
+    assert driver.is_alive() == {'is_alive': False}


### PR DESCRIPTION
`is_alive()` returned `{'is_alive': True}` unconditionally, so a caller couldn't tell a dropped or rebooted session (e.g. after a `rollback()`/replace reboot) from a live one. The binary API exposes no ping/keepalive, so probe with a cheap `/system/identity/print` read: `False` when the API was never opened or the read raises a connection error, `True` otherwise.

Validated live (true on a live session, false after close and when never opened); unit tests cover all three paths.
